### PR TITLE
Fixed PIT timer conflict and PC speaker and cleaned code

### DIFF
--- a/kernel/devices/pci/PCI.c
+++ b/kernel/devices/pci/PCI.c
@@ -3,7 +3,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Abb1x
+ * Copyright (c) 2021 Abb1x, Smart6502
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/kernel/devices/pci/PCI.c
+++ b/kernel/devices/pci/PCI.c
@@ -137,4 +137,3 @@ void PCI_init()
         VBE_putf("[PCI] 00:%x.%d %s: %s %s", device, pci_devices[device].function, PCI_id_to_string(&pci_devices[device]), PCI_vendor_to_string(&pci_devices[device]), PCI_device_id_to_string(&pci_devices[device]));
     }
 }
-

--- a/kernel/devices/pcspkr/pcspkr.c
+++ b/kernel/devices/pcspkr/pcspkr.c
@@ -27,7 +27,7 @@ SOFTWARE.
 #include <libk/logging.h>
 #include <libk/module.h>
 #include <system/interrupts/PIT.h>
-/* FIXME: outb to 0x61 spkrpos is too slow and conflicting with keyboard, we need to use IDT */
+
 void PCSpkr_init()
 {
     IO_outb(0x61, IO_inb(0x61) | 0x1);
@@ -38,25 +38,22 @@ void PCSpkr_init()
 /* Change the c2 f */
 void PCSpkr_set_c2(uint32_t hz)
 {
-    __asm__ volatile("cli");
-    uint32_t div = 1193182 / hz;
-    IO_outb(0x42, 0xB6);
-    IO_outb(0x40, div & 0xFF);
-    IO_outb(0x40, div >> 8);
-    __asm__ volatile("sti");
+    uint32_t div = BASE_FREQ / hz;
+    IO_outb(PIT_CTL, 0xB6);
+    IO_outb(TIMER2_CTL, div & 0xFF);
+    IO_outb(TIMER2_CTL, div >> 8);
 }
 
-void PCSpkr_play(uint32_t frequency)
+void PCSpkr_tone_on(uint32_t frequency)
 {
-    uint8_t tmp;
     PCSpkr_set_c2(frequency);
 
-    tmp = IO_inb(0x61);
+    uint8_t tmp = IO_inb(0x61);
     if (tmp != (tmp | 3))
         IO_outb(0x61, tmp | 3);
 }
 
-void PCSpkr_stop()
+void PCSpkr_tone_off()
 {
     /* Shut it up */
     IO_outb(0x61, IO_inb(0x61) & 0xFC);
@@ -77,10 +74,10 @@ void PCSpkr_beep(uint16_t mstime)
 {
     module("PCSpkr");
     /* I desire thee ears survive ;) */
-    PCSpkr_play(1000);
+    PCSpkr_tone_on(1000);
     PCSpkr_sleep(mstime);
     /* sleep for sometime */
-    PCSpkr_stop();
+    PCSpkr_tone_off();
 
     log(INFO, "Beeped for %d ms!", mstime);
 }

--- a/kernel/devices/pcspkr/pcspkr.h
+++ b/kernel/devices/pcspkr/pcspkr.h
@@ -27,9 +27,8 @@ SOFTWARE.
 #include <stdint.h>
 
 void PCSpkr_init();
-void PCSpkr_set_c2(uint32_t hz);
-void PCSpkr_play(uint32_t frequency);
-void PCSpkr_stop();
+void PCSpkr_tone_on(uint32_t frequency);
+void PCSpkr_tone_off();
 void PCSpkr_sleep(uint16_t delay);
 void PCSpkr_beep(uint16_t mstime);
 #endif

--- a/kernel/devices/video/vbe.c
+++ b/kernel/devices/video/vbe.c
@@ -52,9 +52,9 @@ void VBE_draw_pixel(int x, int y, uint32_t color)
     fb[fb_i] = color;
 }
 
-struct stivale2_struct_tag_framebuffer* VBE_get_fb_info()
+struct stivale2_struct_tag_framebuffer *VBE_get_fb_info()
 {
-  return fb_info;
+    return fb_info;
 }
 void VBE_clear_screen(int info, Color color)
 {
@@ -101,7 +101,7 @@ void VBE_init(struct stivale2_struct *info)
 
         tag = (struct stivale2_tag *)tag->next;
     }
-    
+
     log(INFO, "Framebuffer info:");
     log(INFO, "\t Resolution: %dx%d", fb_info->framebuffer_width, fb_info->framebuffer_height);
     log(INFO, "\t Pitch: %d", fb_info->framebuffer_pitch);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -97,8 +97,8 @@ void kmain(struct stivale2_struct *info)
     uint8_t beeps = 0;
     while (beeps < 3)
     {
-        PCSpkr_beep(55);
-        PCSpkr_sleep(80);
+        PCSpkr_beep(50);
+        PCSpkr_sleep(950);
         beeps++;
     }
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -66,7 +66,7 @@ void kmain(struct stivale2_struct *info)
     info = (void *)info + MEM_OFFSET;
 
     PCI_init();
-/*    BootInfo boot_info = Boot_get_info(info); */
+    /*    BootInfo boot_info = Boot_get_info(info); */
 
     DateTime date = RTC_get_date_time();
 
@@ -76,7 +76,7 @@ void kmain(struct stivale2_struct *info)
 
     srand(RTC_get_seconds());
 
-   /* PMM_init((void*)boot_info.memory_map, boot_info.memory_map->entries);
+    /* PMM_init((void*)boot_info.memory_map, boot_info.memory_map->entries);
 
     VMM_init();*/
 

--- a/kernel/memory/pmm.c
+++ b/kernel/memory/pmm.c
@@ -117,7 +117,7 @@ void PMM_init(struct stivale2_mmap_entry *memory_map, size_t memory_entries)
         if (entry.type == STIVALE2_MMAP_USABLE && entry.length > bitmap_size)
         {
             bitmap = (uint8_t *)entry.base + MEM_OFFSET;
-            log(INFO, "Found place for the bitmap at %x",bitmap);
+            log(INFO, "Found place for the bitmap at %x", bitmap);
         }
     }
 

--- a/kernel/system/interrupts/PIT.c
+++ b/kernel/system/interrupts/PIT.c
@@ -32,11 +32,11 @@ void PIT_init(uint32_t frequency)
 {
     module("PIT");
 
-    uint32_t divisor = 1193181 / frequency;
+    uint32_t divisor = BASE_FREQ / frequency;
 
-    IO_outb(0x43, 0x36);
-    IO_outb(0x40, (uint8_t)divisor & 0xFF);
-    IO_outb(0x40, (uint8_t)(divisor >> 8) & 0xFF);
+    IO_outb(PIT_CTL, 0x36);
+    IO_outb(TIMER0_CTL, (uint8_t)divisor & 0xFF);
+    IO_outb(TIMER0_CTL, (uint8_t)(divisor >> 8) & 0xFF);
 
     log(INFO, "Initialized PIT with frequency: %d Hz", frequency);
 }

--- a/kernel/system/interrupts/PIT.h
+++ b/kernel/system/interrupts/PIT.h
@@ -27,6 +27,13 @@
 #define PIT_H
 #include <stdint.h>
 
+#define TIMER0_CTL 0x40
+/* Reserved for PCSpkr */
+#define TIMER2_CTL 0x42
+#define PIT_CTL 0x43
+
+#define BASE_FREQ 1193182
+
 void PIT_init(uint32_t frequency);
 uint64_t PIT_get_ticks();
 

--- a/kernel/system/panic.c
+++ b/kernel/system/panic.c
@@ -27,7 +27,7 @@ void __panic(char *file, const char function[20], int line, char *message)
 {
     static Color bg_color = {0, 64, 73};
 
-    VBE_clear_screen(0,bg_color);
+    VBE_clear_screen(0, bg_color);
 
     __asm__("cli");
 

--- a/libraries/libk/bitmap.c
+++ b/libraries/libk/bitmap.c
@@ -106,7 +106,7 @@ static size_t allocate(size_t length, Bitmap *self)
     if (self->set_used(block, length) == 0)
     {
         log(WARNING, "Can't set blocks as used");
-	return 0;
+        return 0;
     }
 
     return block;
@@ -130,6 +130,5 @@ Bitmap _Bitmap(uint8_t *data, size_t size)
     new_bitmap.find_free = find_free;
     new_bitmap.allocate = allocate;
 
-    
     return new_bitmap;
 }

--- a/libraries/libk/io.c
+++ b/libraries/libk/io.c
@@ -58,7 +58,7 @@ uint32_t IO_inl(uint16_t port)
 
 void IO_outw(unsigned short port, unsigned short value)
 {
-   __asm__ volatile("outw %%ax,%%dx"
-                :
-                : "dN"(port), "a"(value));
+    __asm__ volatile("outw %%ax,%%dx"
+                     :
+                     : "dN"(port), "a"(value));
 }

--- a/libraries/libk/string.c
+++ b/libraries/libk/string.c
@@ -103,5 +103,4 @@ void printf(char *format, ...)
     }
 
     va_end(arg);
-
 }


### PR DESCRIPTION
PIT timer 0 was having problems because of the PC speaker sending stuff to the wrong ports